### PR TITLE
fix: hanspell 모듈 실행 결과에서 데이터 사라지는 오류

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/grammar_checker/grammar.py
+++ b/grammar_checker/grammar.py
@@ -32,7 +32,7 @@ def print_fixed_grammar(path):
         error_count += result.errors
 
         corrected_line = ""
-        for key, value in result.words.items():
+        for key, value in result.words:
             corrected_word = key
 
             if value == CheckResult.AMBIGUOUS:

--- a/grammar_checker/hanspell/spell_checker.py
+++ b/grammar_checker/hanspell/spell_checker.py
@@ -79,7 +79,7 @@ def check(text):
                .replace('<span class=\'violet_text\'>', '<violet>') \
                .replace('<span class=\'blue_text\'>', '<blue>') \
                .replace('</span>', '<end>')
-    items = html.split(' ')
+    items = unescape(html).split(' ')
     words = []
     tmp = ''
     for word in items:
@@ -109,7 +109,7 @@ def check(text):
         elif word[:6] == '<blue>':
             check_result = CheckResult.STATISTICAL_CORRECTION
             word = word.replace('<blue>', '')
-        result['words'].append((unescape(word), check_result))
+        result['words'].append((word, check_result))
 
     result = Checked(**result)
 

--- a/grammar_checker/hanspell/spell_checker.py
+++ b/grammar_checker/hanspell/spell_checker.py
@@ -7,8 +7,8 @@ import requests
 import json
 import time
 import sys
-from collections import OrderedDict
 import xml.etree.ElementTree as ET
+from html import unescape
 
 from . import __version__
 from .response import Checked
@@ -68,7 +68,7 @@ def check(text):
         'checked': _remove_tags(html),
         'errors': data['message']['result']['errata_count'],
         'time': passed_time,
-        'words': OrderedDict(),
+        'words': list(),
     }
 
     # 띄어쓰기로 구분하기 위해 태그는 일단 보기 쉽게 바꿔둠.
@@ -109,7 +109,7 @@ def check(text):
         elif word[:6] == '<blue>':
             check_result = CheckResult.STATISTICAL_CORRECTION
             word = word.replace('<blue>', '')
-        result['words'][word] = check_result
+        result['words'].append((unescape(word), check_result))
 
     result = Checked(**result)
 


### PR DESCRIPTION
- hanspell 모듈에서 결과를 저장할 때 key로 단어로 하는 dict를 사용함으로써 동일한 단어들이 사라지는 현상 해결함 (list 사용)
- `<br>` 같은 단어가 `&lt;br&gt` 같은 html 인코딩된 형태로 변하는 부분 해결함